### PR TITLE
Apply to list

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -121,7 +121,7 @@ A reminder for the maintainers on how to deploy.
 Make sure all your changes are committed (including an entry in HISTORY.rst).
 Then run::
 
-$ bump2version patch # possible: major / minor / patch
+$ bump-my-version bump patch # possible: major / minor / patch, add --dry-run -vv for dry-run.
 $ git push origin <tag_name>
 
 Travis will then deploy to PyPI if tests pass.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -62,7 +62,8 @@ Bugfixes to ganja.js integration:
 * `pretty_blade` options added to algebra, to allow users to choose the printing of basis blades.
 * getattr bugfix
 
-1.2.0 (2024-12-06)
+1.2.0 (2024-12-16)
 ------------------
 * Binary operators are now broadcasted across lists and tuples, e.g. `R >> [point1, point2]`.
 * Projection (@) and conjugation (>>) are now symbolically optimized by default.
+* Matrix reps made with `expr_as_matrix` now have better support for numerical (and multidimensional) multivectors.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -64,5 +64,5 @@ Bugfixes to ganja.js integration:
 
 1.2.0 (2024-12-06)
 ------------------
-* Binary operators are not broadcasted accross lists and tuples, e.g. `R >> [point1, point2]`.
+* Binary operators are now broadcasted across lists and tuples, e.g. `R >> [point1, point2]`.
 * Projection (@) and conjugation (>>) are now symbolically optimized by default.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -61,3 +61,8 @@ Bugfixes to ganja.js integration:
 * Improved printing, especially for multivector with array or multivector coefficients.
 * `pretty_blade` options added to algebra, to allow users to choose the printing of basis blades.
 * getattr bugfix
+
+1.2.0 (2024-12-06)
+------------------
+* Binary operators are not broadcasted accross lists and tuples, e.g. `R >> [point1, point2]`.
+* Projection (@) and conjugation (>>) are now symbolically optimized by default.

--- a/docs/module_docs.rst
+++ b/docs/module_docs.rst
@@ -67,6 +67,6 @@ Taperecorder
 
 Used `Algebra.register` to generate code.
 
-.. automodule:: kingdon.polynomial
+.. automodule:: kingdon.taperecorder
    :members:
    :undoc-members:

--- a/docs/module_docs.rst
+++ b/docs/module_docs.rst
@@ -61,3 +61,12 @@ Rational Polynomial
 .. automodule:: kingdon.polynomial
    :members:
    :undoc-members:
+
+Taperecorder
+------------
+
+Used `Algebra.register` to generate code.
+
+.. automodule:: kingdon.polynomial
+   :members:
+   :undoc-members:

--- a/kingdon/__init__.py
+++ b/kingdon/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Martin Roelfs"""
 __email__ = 'martinroelfs@yahoo.com'
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 from sympy import symbols
 

--- a/kingdon/algebra.py
+++ b/kingdon/algebra.py
@@ -68,7 +68,7 @@ class Algebra:
 
     # Clever dictionaries that cache previously symbolically optimized lambda functions between elements.
     gp: OperatorDict = operation_field(metadata={'codegen': codegen_gp})  # geometric product
-    sw: Registry = operation_field(metadata={'codegen': codegen_sw})  # conjugation
+    sw: OperatorDict = operation_field(metadata={'codegen': codegen_sw})  # conjugation
     cp: OperatorDict = operation_field(metadata={'codegen': codegen_cp})  # commutator product
     acp: OperatorDict = operation_field(metadata={'codegen': codegen_acp})  # anti-commutator product
     ip: OperatorDict = operation_field(metadata={'codegen': codegen_ip})  # inner product
@@ -77,7 +77,7 @@ class Algebra:
     rc: OperatorDict = operation_field(metadata={'codegen': codegen_rc})  # right-contraction
     op: OperatorDict = operation_field(metadata={'codegen': codegen_op})  # exterior product
     rp: OperatorDict = operation_field(metadata={'codegen': codegen_rp})  # regressive product
-    proj: Registry = operation_field(metadata={'codegen': codegen_proj})  # projection
+    proj: OperatorDict = operation_field(metadata={'codegen': codegen_proj})  # projection
     add: OperatorDict = operation_field(metadata={'codegen': codegen_add})  # add
     sub: OperatorDict = operation_field(metadata={'codegen': codegen_sub})  # sub
     div: OperatorDict = operation_field(metadata={'codegen': codegen_div})  # division

--- a/kingdon/matrixreps.py
+++ b/kingdon/matrixreps.py
@@ -6,6 +6,8 @@ This follows the approach outlined in
 Graded Symmetry Groups: Plane and Simple, section 10.
 See the paper for more details.
 """
+import itertools
+import string
 from functools import reduce
 from itertools import combinations
 from typing import Callable
@@ -95,7 +97,21 @@ def expr_as_matrix(expr: Callable, *inputs, res_like: "MultiVector" = None):
 
     In order to build the matrix rep the input `expr` is evaluated, so make sure the inputs
     to the expression are given in the correct order.
-    The last of the positional arguments is assumed to be the vector x.
+    The last of the positional arguments is assumed to be the vector x in the linear equation y = Ax,
+    and is *assumed to be symbolic*.
+    The other arguments can also be numeric or e.g. a multidimensional array/torsor, in which case the
+    returned matrix A will be numerical as well. This can e.g. be used to easily generate the matrix
+    representations of a given (dual-)quaternion::
+
+        >>> alg = Algebra(3, 0, 1)
+        >>> R = alg.evenmv(e12=0.25*numpy.pi).exp()
+        >>> x = alg.vector(name='x')
+        >>> A, y = expr_as_matrix(lambda R, x: R >> x, R, x)
+        >>> A
+        [[ 1.  0.  0.  0.]
+         [ 0.  0.  1.  0.]
+         [ 0. -1.  0.  0.]
+         [ 0.  0.  0.  1.]]
 
     :expr: Callable representing a valid GA expression.
         Can also be a :class:`~kingdon.operator_dict.OperatorDict`.

--- a/kingdon/matrixreps.py
+++ b/kingdon/matrixreps.py
@@ -134,7 +134,7 @@ def expr_as_matrix(expr: Callable, *inputs, res_like: "MultiVector" = None):
         symbolic_inputs = [*symbolic_rest, x]
         A, y = expr_as_matrix(expr, *symbolic_inputs, res_like=res_like,)
         symbols2values = dict(itertools.chain(*(zip(smv.values(), mv.values()) for smv, mv in zip(symbolic_rest, rest))))
-        func = sympy.lambdify(symbols2values.keys(), A)
+        func = sympy.lambdify(symbols2values.keys(), A, modules={'ImmutableDenseMatrix': list})
         kwargs = {str(k): v for k, v in symbols2values.items()}
         A = func(**kwargs)  # TODO: vectorize this call correctly
         symbols2values.update({v: v for v in x.values()})

--- a/kingdon/matrixreps.py
+++ b/kingdon/matrixreps.py
@@ -118,7 +118,7 @@ def expr_as_matrix(expr: Callable, *inputs, res_like: "MultiVector" = None):
         Can also be a :class:`~kingdon.operator_dict.OperatorDict`.
     :inputs: All positional arguments are consider symbolic input arguments to `expr`. The last of these is assumed to
         represent the vector `x` in `y = Ax`.
-    :res_like: optional multivector corresponding to the desired output. If None, then the full output is returned.
+    :res_like: (optional) multivector corresponding to the desired output. If None, then the full output is returned.
         However, if only a subsegment of the output is desired, provide a multivector with the desired shape.
         In the example above setting, `res_like = alg.vector(e1=1)` would mean only the e1 component of the matrix
         is returned. This does not have to be a symbolic multivector, only the keys are checked.
@@ -136,7 +136,7 @@ def expr_as_matrix(expr: Callable, *inputs, res_like: "MultiVector" = None):
         symbols2values = dict(itertools.chain(*(zip(smv.values(), mv.values()) for smv, mv in zip(symbolic_rest, rest))))
         func = sympy.lambdify(symbols2values.keys(), A)
         kwargs = {str(k): v for k, v in symbols2values.items()}
-        A = func(**kwargs)
+        A = func(**kwargs)  # TODO: vectorize this call correctly
         symbols2values.update({v: v for v in x.values()})
         y = y(**{str(k): v for k, v in symbols2values.items() if k in y.free_symbols})
         return A, y

--- a/kingdon/operator_dict.py
+++ b/kingdon/operator_dict.py
@@ -88,6 +88,12 @@ class OperatorDict(Mapping):
             mv1 = mv1()
         while isinstance(mv2, Callable) and not isinstance(mv2, MultiVector):
             mv2 = mv2()
+        # If mv2 is a list, apply mv1 to all elements in the list
+        if isinstance(mv2, (tuple, list)):
+            return type(mv2)(self._call_binary(mv1, mv) for mv in mv2)
+        # If mv1 is a list, apply mv2 to all elements in the list
+        if isinstance(mv1, (tuple, list)):
+            return type(mv1)(self._call_binary(mv, mv2) for mv in mv1)
 
         # Make sure all inputs are multivectors. If an input is not, assume its scalar.
         mv1 = mv1 if isinstance(mv1, MultiVector) else MultiVector.fromkeysvalues(self.algebra, (0,), [mv1])

--- a/kingdon/taperecorder.py
+++ b/kingdon/taperecorder.py
@@ -24,9 +24,16 @@ class TapeRecorder:
         return int(''.join('1' if i in self.keys() else '0' for i in reversed(self.algebra.canon2bin.values())), 2)
 
     def __getattr__(self, basis_blade):
-        bin_blade = self.algebra.canon2bin[basis_blade]
+        if not re.match(r'^e[0-9a-fA-F]*$', basis_blade):
+            raise AttributeError(f'{self.__class__.__name__} object has no attribute or basis blade {basis_blade}')
+        if basis_blade not in self.algebra.canon2bin:
+            return self.__class__(
+                algebra=self.algebra,
+                expr=f"(0,)",
+                keys=(0,)
+            )
         try:
-            idx = self.keys().index(bin_blade)
+            idx = self.keys().index(self.algebra.canon2bin[basis_blade])
         except ValueError:
             return self.__class__(
                 algebra=self.algebra,
@@ -135,3 +142,11 @@ class TapeRecorder:
             raise Exception('Cannot select a suitable undual in auto mode for this algebra.')
         else:
             raise ValueError(f'No undual found for kind={kind}.')
+
+    def norm(self):
+        normsq = self.normsq()
+        return normsq.sqrt()
+
+    def normalized(self):
+        """ Normalized version of this multivector. """
+        return self / self.norm()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.1.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/tbuli/kingdon',
-    version='1.1.1',
+    version='1.1.2',
     zip_safe=False,
 )

--- a/tests/test_expr_as_matrix.py
+++ b/tests/test_expr_as_matrix.py
@@ -1,6 +1,8 @@
-from kingdon import Algebra
+from sympy import Matrix
+import numpy as np
+
+from kingdon import Algebra, MultiVector
 from kingdon.matrixreps import expr_as_matrix
-from sympy import Matrix, pprint
 
 
 def test_expr_as_matrix():
@@ -32,3 +34,25 @@ def test_expr_as_matrix():
     A, y = expr_as_matrix(alg.sw, B, x)
     assert A == Matrix([[2*B12*B23], [-2*B12*B13], [B12**2 - B13**2 - B23**2]])
     assert [alg.bin2canon[k] for k in y.keys()] == ['e1', 'e2', 'e3']
+
+def test_expr_as_matrix_numerical():
+    alg = Algebra(3, 0, 1)
+    Bvals = np.random.random(len(alg.blades.grade(2)))
+    x = alg.vector(name='x')
+    B = alg.bivector(Bvals)
+
+    # Test for the matrix rep of the commutator. (Grade preserving)
+    A, y = expr_as_matrix(alg.cp, B, x)
+    assert type(A) == np.ndarray
+    assert type(y) == MultiVector
+    assert A.shape == (4, 4)
+
+    Bvals = np.random.random((len(alg.blades.grade(2)), 10))
+    x = alg.vector(name='x')
+    B = alg.bivector(Bvals)
+
+    # Test for the matrix rep of the commutator. (Grade preserving)
+    A, y = expr_as_matrix(alg.cp, B, x)
+    assert type(A) == np.ndarray
+    assert type(y) == MultiVector
+    assert A.shape == (4, 4)

--- a/tests/test_expr_as_matrix.py
+++ b/tests/test_expr_as_matrix.py
@@ -30,5 +30,5 @@ def test_expr_as_matrix():
     # Test for the matrix rep of conjugation of the e3 plane.
     x = alg.vector(name='x', keys=('e3',))
     A, y = expr_as_matrix(alg.sw, B, x)
-    assert A == Matrix([[2*B12*B23], [-2*B12*B13], [B12**2 - B13**2 - B23**2], [0]])
-    assert [alg.bin2canon[k] for k in y.keys()] == ['e1', 'e2', 'e3', 'e123']
+    assert A == Matrix([[2*B12*B23], [-2*B12*B13], [B12**2 - B13**2 - B23**2]])
+    assert [alg.bin2canon[k] for k in y.keys()] == ['e1', 'e2', 'e3']

--- a/tests/test_expr_as_matrix.py
+++ b/tests/test_expr_as_matrix.py
@@ -53,6 +53,5 @@ def test_expr_as_matrix_numerical():
 
     # Test for the matrix rep of the commutator. (Grade preserving)
     A, y = expr_as_matrix(alg.cp, B, x)
-    assert type(A) == np.ndarray
+    assert type(A) == list
     assert type(y) == MultiVector
-    assert A.shape == (4, 4)

--- a/tests/test_kingdon.py
+++ b/tests/test_kingdon.py
@@ -2,6 +2,7 @@
 
 """Tests for `kingdon` package."""
 import itertools
+import operator
 from dataclasses import replace
 
 import pytest
@@ -901,3 +902,23 @@ def test_nested_algebra_print():
     x = dalg.multivector(e='x', e0=1)
     x = dalg2.multivector(e=x, e0=1)
     assert str(x ** 2) == "((x**2) + (2*x) 𝐞₀) + ((2*x) + 2 𝐞₀) 𝒇₀"
+
+def test_apply_to_list():
+    alg = Algebra(2, 0, 1)
+    line1 = alg.vector(e1=-1, e2=1)  # the line "y - x = 0"
+    line2 = alg.vector(e1=-1, e2=2)
+    R = (line1 * line2).normalized()
+    triangle = [
+        alg.vector(e0=1, e1=1).dual(),
+        alg.vector(e0=1, e1=0.6, e2=0.5).dual(),
+        alg.vector(e0=1, e1=1.3, e2=0.8).dual()
+    ]
+    operators = [operator.mul, operator.xor, operator.and_, operator.rshift]
+    for op in operators:
+        transformed_subjects = op(R, triangle)
+        for i, p in enumerate(triangle):
+            assert op(R, p) == transformed_subjects[i]
+
+        transformed_subjects = op(triangle, R)
+        for i, p in enumerate(triangle):
+            assert op(p, R) == transformed_subjects[i]


### PR DESCRIPTION
* Binary operators are now broadcasted across lists and tuples, e.g. `R >> [point1, point2]`.
* Projection (@) and conjugation (>>) are now symbolically optimized by default.