### PR TITLE
Codegen speed improvement

### DIFF
--- a/kingdon/algebra.py
+++ b/kingdon/algebra.py
@@ -76,31 +76,31 @@ class Algebra:
     basis: List[str] = field(repr=False, default_factory=list)
 
     # Clever dictionaries that cache previously symbolically optimized lambda functions between elements.
-    gp: OperatorDict = operation_field(metadata={'codegen': codegen_gp})  # geometric product
+    gp: OperatorDict = operation_field(metadata={'codegen': codegen_gp, 'codegen_symbolcls': str})  # geometric product
     sw: OperatorDict = operation_field(metadata={'codegen': codegen_sw})  # conjugation
-    cp: OperatorDict = operation_field(metadata={'codegen': codegen_cp})  # commutator product
-    acp: OperatorDict = operation_field(metadata={'codegen': codegen_acp})  # anti-commutator product
-    ip: OperatorDict = operation_field(metadata={'codegen': codegen_ip})  # inner product
-    sp: OperatorDict = operation_field(metadata={'codegen': codegen_sp})  # Scalar product
-    lc: OperatorDict = operation_field(metadata={'codegen': codegen_lc})  # left-contraction
-    rc: OperatorDict = operation_field(metadata={'codegen': codegen_rc})  # right-contraction
-    op: OperatorDict = operation_field(metadata={'codegen': codegen_op})  # exterior product
-    rp: OperatorDict = operation_field(metadata={'codegen': codegen_rp})  # regressive product
+    cp: OperatorDict = operation_field(metadata={'codegen': codegen_cp, 'codegen_symbolcls': str})  # commutator product
+    acp: OperatorDict = operation_field(metadata={'codegen': codegen_acp, 'codegen_symbolcls': str})  # anti-commutator product
+    ip: OperatorDict = operation_field(metadata={'codegen': codegen_ip, 'codegen_symbolcls': str})  # inner product
+    sp: OperatorDict = operation_field(metadata={'codegen': codegen_sp, 'codegen_symbolcls': str})  # Scalar product
+    lc: OperatorDict = operation_field(metadata={'codegen': codegen_lc, 'codegen_symbolcls': str})  # left-contraction
+    rc: OperatorDict = operation_field(metadata={'codegen': codegen_rc, 'codegen_symbolcls': str})  # right-contraction
+    op: OperatorDict = operation_field(metadata={'codegen': codegen_op, 'codegen_symbolcls': str})  # exterior product
+    rp: OperatorDict = operation_field(metadata={'codegen': codegen_rp, 'codegen_symbolcls': str})  # regressive product
     proj: OperatorDict = operation_field(metadata={'codegen': codegen_proj})  # projection
-    add: OperatorDict = operation_field(metadata={'codegen': codegen_add})  # add
-    sub: OperatorDict = operation_field(metadata={'codegen': codegen_sub})  # sub
+    add: OperatorDict = operation_field(metadata={'codegen': codegen_add, 'codegen_symbolcls': str})  # add
+    sub: OperatorDict = operation_field(metadata={'codegen': codegen_sub, 'codegen_symbolcls': str})  # sub
     div: OperatorDict = operation_field(metadata={'codegen': codegen_div})  # division
     # Unary operators
     inv: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_inv})  # inverse
-    neg: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_neg})  # negate
-    reverse: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_reverse})  # reverse
-    involute: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_involute})  # grade involution
-    conjugate: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_conjugate})  # clifford conjugate
+    neg: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_neg, 'codegen_symbolcls': str})  # negate
+    reverse: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_reverse, 'codegen_symbolcls': str})  # reverse
+    involute: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_involute, 'codegen_symbolcls': str})  # grade involution
+    conjugate: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_conjugate, 'codegen_symbolcls': str})  # clifford conjugate
     sqrt: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_sqrt})  # Square root
     polarity: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_polarity})
     unpolarity: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_unpolarity})
-    hodge: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_hodge})
-    unhodge: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_unhodge})
+    hodge: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_hodge, 'codegen_symbolcls': str})
+    unhodge: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_unhodge, 'codegen_symbolcls': str})
     normsq: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_normsq})  # norm squared
     outerexp: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_outerexp})
     outersin: UnaryOperatorDict = operation_field(metadata={'codegen': codegen_outersin})
@@ -185,7 +185,7 @@ class Algebra:
         self.pss = self.blades[self.bin2canon[2 ** self.d - 1]]
 
         # Prepare OperatorDict's
-        self.registry = {f.name: f.type(name=f.name, codegen=f.metadata['codegen'], algebra=self)
+        self.registry = {f.name: f.type(name=f.name, algebra=self, **f.metadata)
                          for f in fields(self) if 'codegen' in f.metadata}
         for name, operator_dict in self.registry.items():
             setattr(self, name, operator_dict)

--- a/kingdon/codegen.py
+++ b/kingdon/codegen.py
@@ -74,23 +74,6 @@ def power_supply(x: "MultiVector", exponents: Tuple[int, ...], operation: Callab
         yield powers[step]
 
 
-class TermTuple(NamedTuple):
-    """
-    TermTuple represents a single monomial in a product of multivectors.
-
-    :param key_out: is the basis blade to which this monomial belongs.
-    :param keys_in: are the input basis blades in this monomial.
-    :param sign: Sign of the monomial.
-    :param values_in: Input values. Typically, tuple of :class:`sympy.core.symbol.Symbol`.
-    :param termstr: The string representation of this monomial, e.g. '-x*y'.
-    """
-    key_out: int
-    keys_in: Tuple[int]
-    sign: int
-    values_in: Tuple["sympy.core.symbol.Symbol"]
-    termstr: str
-
-
 class CodegenOutput(NamedTuple):
     """
     Output of a codegen function.
@@ -101,19 +84,6 @@ class CodegenOutput(NamedTuple):
     """
     keys_out: Tuple[int]
     func: Callable
-
-
-def term_tuple(items, sign_func, keyout_func=operator.xor):
-    """
-    Create a single term in a multivector product between the basis blades present in `items`.
-    """
-    keys_in, values_in = zip(*items)
-    sign = sign_func(keys_in)
-    if not sign:
-        return TermTuple(key_out=0, keys_in=keys_in, sign=sign, values_in=values_in, termstr='')
-    key_out = keyout_func(*keys_in)
-    return TermTuple(key_out, keys_in, sign, values_in,
-                     f'{"+" if sign > 0 else "-"}{"*".join(str(v) for v in values_in)}')
 
 
 def codegen_product(x, y, filter_func=None, sign_func=None, keyout_func=operator.xor):
@@ -128,23 +98,19 @@ def codegen_product(x, y, filter_func=None, sign_func=None, keyout_func=operator
         for metric dependent products. Input: 2-tuple of blade indices, e.g. (ei, ej).
     :param keyout_func:
     """
-    algebra = x.algebra
-    if sign_func is None:
-        sign_func = lambda pair: algebra.signs[pair]
+    sign_func = sign_func or (lambda pair: x.algebra.signs[pair])
 
-    # If sign == 0, then the term should be disregarded since it is zero
-    terms = filter(lambda tt: tt.sign, (term_tuple(items, sign_func, keyout_func=keyout_func)
-                                        for items in product(x.items(), y.items())))
-    if filter_func is not None:
-        terms = filter(filter_func, terms)
-
-    res = defaultdict(str)
-    for term in terms:
-        if term.key_out in res:
-            res[term.key_out] += term.termstr
-        else:
-            res[term.key_out] = term.termstr[1:] if term.termstr[0] == '+' else term.termstr
-    return dict(sorted(res.items()))
+    res = {}
+    for (kx, vx), (ky, vy) in product(x.items(), y.items()):
+        if (sign := sign_func((kx, ky))):
+            key_out = keyout_func(kx, ky)
+            if filter_func and not filter_func(kx, ky, key_out): continue
+            termstr = f'{"+" if sign > 0 else "-"}{vx}*{vy}'
+            if key_out in res:
+                res[key_out] += termstr
+            else:
+                res[key_out] = termstr[1:] if termstr[0] == '+' else termstr
+    return res
 
 
 def codegen_gp(x, y):
@@ -175,7 +141,7 @@ def codegen_cp(x, y):
     :return: tuple of keys in binary representation and a lambda function.
     """
     algebra = x.algebra
-    filter_func = lambda tt: (algebra.signs[tt.keys_in] - algebra.signs[tt.keys_in[::-1]])
+    filter_func = lambda kx, ky, k_out: (algebra.signs[kx, ky] - algebra.signs[ky, kx])
     return codegen_product(x, y, filter_func=filter_func)
 
 
@@ -186,7 +152,7 @@ def codegen_acp(x, y):
     :return: tuple of keys in binary representation and a lambda function.
     """
     algebra = x.algebra
-    filter_func = lambda tt: (algebra.signs[tt.keys_in] + algebra.signs[tt.keys_in[::-1]])
+    filter_func = lambda kx, ky, k_out: (algebra.signs[kx, ky] + algebra.signs[ky, kx])
     return codegen_product(x, y, filter_func=filter_func)
 
 
@@ -199,8 +165,7 @@ def codegen_ip(x, y, diff_func=abs):
         function generates left-contraction, and when :code:`lambda x: x`, right-contraction.
     :return: tuple of keys in binary representation and a lambda function.
     """
-    algebra = x.algebra
-    filter_func = lambda tt: tt.key_out == diff_func(tt.keys_in[0] - tt.keys_in[1])
+    filter_func = lambda kx, ky, k_out: k_out == diff_func(kx - ky)
     return codegen_product(x, y, filter_func=filter_func)
 
 
@@ -250,9 +215,8 @@ def codegen_op(x, y):
         and values which are a 3-tuple of indices in `x`, indices in `y`, and a lambda function.
     """
     algebra = x.algebra
-    filter_func = lambda tt: tt.key_out == sum(tt.keys_in)
-    sign_func = lambda pair: (-1)**algebra.swaps[pair]
-    return codegen_product(x, y, filter_func=filter_func, sign_func=sign_func)
+    filter_func = lambda kx, ky, k_out: k_out == kx + ky
+    return codegen_product(x, y, filter_func=filter_func)
 
 
 def codegen_rp(x, y):
@@ -465,7 +429,7 @@ def codegen_add(x, y):
     vals = dict(x.items())
     for k, v in y.items():
         if k in vals:
-            vals[k] = vals[k] + v
+            vals[k] = f'{vals[k]}+{v}'
         else:
             vals[k] = v
     return vals
@@ -475,13 +439,13 @@ def codegen_sub(x, y):
     vals = dict(x.items())
     for k, v in y.items():
         if k in vals:
-            vals[k] = vals[k] - v
+            vals[k] = f'{vals[k]}-{v}'
         else:
-            vals[k] = -v
+            vals[k] = '-'+v
     return vals
 
 def codegen_neg(x):
-    return {k: -v for k, v in x.items()}
+    return {k: '-'+v for k, v in x.items()}
 
 
 def codegen_involutions(x, invert_grades=(2, 3)):
@@ -491,7 +455,7 @@ def codegen_involutions(x, invert_grades=(2, 3)):
 
     :param invert_grades: The grades that flip sign under this involution mod 4, e.g. (2, 3) for reversion.
     """
-    return {k: -v if bin(k).count('1') % 4 in invert_grades else v
+    return {k: '-'+v if bin(k).count('1') % 4 in invert_grades else v
             for k, v in x.items()}
 
 
@@ -546,10 +510,11 @@ def codegen_sqrt(x):
 def codegen_polarity(x, undual=False):
     if undual:
         return x * x.algebra.pss
-    sign = x.algebra.signs[-1, -1]
-    if sign == 1:
-        return x * x.algebra.pss
+    key_pss = len(x.algebra) - 1
+    sign = x.algebra.signs[key_pss, key_pss]
     if sign == -1:
+        return x * x.algebra.pss
+    if sign == 1:
         return x * (-x.algebra.pss)
     if sign == 0:
         raise ZeroDivisionError
@@ -561,14 +526,10 @@ def codegen_unpolarity(x):
 
 def codegen_hodge(x, undual=False):
     if undual:
-        return x.algebra.multivector(
-            {len(x.algebra) - 1 - eI: x.algebra.signs[len(x.algebra) - 1 - eI, eI] * val
-             for eI, val in x.items()}
-        )
-    return x.algebra.multivector(
-        {len(x.algebra) - 1 - eI: x.algebra.signs[eI, len(x.algebra) - 1 - eI] * val
-         for eI, val in x.items()}
-    )
+        return {(key_dual := len(x.algebra) - 1 - eI): f'-{v}' if x.algebra.signs[key_dual, eI] < 0 else v
+                for eI, v in x.items()}
+    return {(key_dual := len(x.algebra) - 1 - eI): f'-{v}' if x.algebra.signs[eI, key_dual] < 0 else v
+            for eI, v in x.items()}
 
 
 def codegen_unhodge(x):

--- a/kingdon/codegen.py
+++ b/kingdon/codegen.py
@@ -514,9 +514,9 @@ def codegen_polarity(x, undual=False):
     key_pss = len(x.algebra) - 1
     sign = x.algebra.signs[key_pss, key_pss]
     if sign == -1:
-        return x * x.algebra.pss
+        return - x * x.algebra.pss
     if sign == 1:
-        return x * (-x.algebra.pss)
+        return x * x.algebra.pss
     if sign == 0:
         raise ZeroDivisionError
 

--- a/kingdon/codegen.py
+++ b/kingdon/codegen.py
@@ -555,7 +555,6 @@ def do_codegen(codegen, *mvs) -> CodegenOutput:
     :return: Instance of :class:`CodegenOutput`.
     """
     algebra = mvs[0].algebra
-    namespace = algebra.numspace
 
     res = codegen(*mvs)
 

--- a/kingdon/codegen.py
+++ b/kingdon/codegen.py
@@ -229,14 +229,15 @@ def codegen_rp(x, y):
     :return: tuple of keys in binary representation and a lambda function.
     """
     algebra = x.algebra
-    keyout_func = lambda tot, key_in: len(algebra) - 1 - (key_in ^ tot)
-    filter_func = lambda tt: len(algebra) - 1 == sum(tt.keys_in) - tt.key_out
+    key_pss = len(algebra) - 1
+    keyout_func = lambda kx, ky: key_pss - (kx ^ ky)
+    filter_func = lambda kx, ky, k_out: key_pss == kx + ky - k_out
     # Sign is composed of dualization of each blade, exterior product, and undual.
     sign_func = lambda pair: (
-        algebra.signs[pair[0], len(algebra) - 1 - pair[0]] *
-        algebra.signs[pair[1], len(algebra) - 1 - pair[1]] *
-        (-1)**algebra.swaps[len(algebra) - 1 - pair[0], len(algebra) - 1 - pair[1]] *
-        algebra.signs[len(algebra) - 1 - (pair[0] ^ pair[1]), pair[0] ^ pair[1]]
+        algebra.signs[pair[0], key_pss - pair[0]] *
+        algebra.signs[pair[1], key_pss - pair[1]] *
+        algebra.signs[key_pss - pair[0], key_pss - pair[1]] *
+        algebra.signs[key_pss - (pair[0] ^ pair[1]), pair[0] ^ pair[1]]
     )
 
     return codegen_product(

--- a/kingdon/multivector.py
+++ b/kingdon/multivector.py
@@ -581,9 +581,9 @@ class MultiVector:
     def dual(self, kind='auto'):
         """
         Compute the dual of `self`. There are three different kinds of duality in common usage.
-        The first is polarity, which is simply multiplying by the inverse PSS. This is the only game in town for
-        non-degenerate metrics (Algebra.r = 0). However, for degenerate spaces this no longer works, and we have
-        two popular options: Poincaré and Hodge duality.
+        The first is polarity, which is simply multiplying by the inverse PSS from the right. This is the only game in
+        town for non-degenerate metrics (Algebra.r = 0). However, for degenerate spaces this no longer works, and we
+        have two popular options: Poincaré and Hodge duality.
 
         By default, :code:`kingdon` will use polarity in non-degenerate spaces, and Hodge duality for spaces with
         `Algebra.r = 1`. For spaces with `r > 2`, little to no literature exists, and you are on your own.

--- a/kingdon/multivector.py
+++ b/kingdon/multivector.py
@@ -9,6 +9,7 @@ import re
 from sympy import Expr, Symbol, sympify, sinc, cos
 
 from kingdon.codegen import _lambdify_mv
+from kingdon.polynomial import RationalPolynomial
 
 
 @dataclass(init=False)
@@ -83,7 +84,7 @@ class MultiVector:
             keys = tuple(key if key in algebra.bin2canon else algebra.canon2bin[key]
                          for key in keys)
 
-        if any(isinstance(v, str) for v in values):
+        if symbolcls is not str and any(isinstance(v, str) for v in values):
             values = list(val if not isinstance(val, str) else sympify(val)
                           for val in values)
 
@@ -180,10 +181,11 @@ class MultiVector:
     @cached_property
     def issymbolic(self):
         """ True if this mv contains Symbols, False otherwise. """
-        # Allowed symbol classes. codegen_symbolcls might refer to a constructor (method): get the class instead.
-        symbol_classes = (Expr, self.algebra.codegen_symbolcls.__self__
-                                if hasattr(self.algebra.codegen_symbolcls, '__self__')
-                                else self.algebra.codegen_symbolcls)
+        symbol_classes = (Expr, RationalPolynomial)
+        if self.algebra.codegen_symbolcls:
+            # Allowed symbol classes. codegen_symbolcls might refer to a constructor (method): get the class instead.
+            symbolcls = self.algebra.codegen_symbolcls
+            symbol_classes = (*symbol_classes, symbolcls.__self__ if hasattr(symbolcls, '__self__') else symbolcls)
         return any(isinstance(v, symbol_classes) for v in self.values())
 
     def neg(self):

--- a/tests/test_kingdon.py
+++ b/tests/test_kingdon.py
@@ -293,6 +293,13 @@ def test_hodge_dual(pga2d, pga3d):
     z = y.undual()
     assert z == x
 
+def test_polarity():
+    alg = Algebra(4, 1)
+    x = alg.multivector(name='x')
+    xdual = x.polarity()
+    assert not (xdual - x * alg.pss).values()
+    assert not (xdual.unpolarity() - x).values()
+
 def test_regressive(pga3d):
     """ Test the regressive product of full mvs in 3DPGA against the known result from GAmphetamine.js"""
     xvals = symbols(','.join(f'x{i}' for i in range(1, len(pga3d) + 1)))

--- a/tests/test_kingdon.py
+++ b/tests/test_kingdon.py
@@ -297,7 +297,7 @@ def test_polarity():
     alg = Algebra(4, 1)
     x = alg.multivector(name='x')
     xdual = x.polarity()
-    assert not (xdual - x * alg.pss).values()
+    assert not (xdual - x * alg.pss.inv()).values()
     assert not (xdual.unpolarity() - x).values()
 
 def test_regressive(pga3d):


### PR DESCRIPTION
The speed of codegen has been significantly improved, by a factor of 2.5 for the geometric product, and up to 16 times more for some other operators. This was possible because the codegen was still to general, written to be able to compute all the products between any number of arguments in one go. But now that the design has settled, we should go for specialized implementations instead, and use strings instead of RationalPolynomials when possible.

| | | From | | | To | | | |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Alg | Operator | Init | Exec | Ratio | Init | Exec | Ratio | From/To Ratio |
| (2, 0, 1) | | 1.15e-04 | | | 1.12e-04 |
| | gp | 3.00e-04 | 4.70e-06 | 64 | 1.17e-04 | 4.56e-06 | 26 | **2.49**
| | cp | 2.80e-04 | 3.40e-06 | 82 | 9.39e-05 | 3.26e-06 | 29 | **2.86**
| | acp | 2.91e-04 | 3.89e-06 | 75 | 1.06e-04 | 3.80e-06 | 28 | **2.69**
| | ip | 2.87e-04 | 3.99e-06 | 72 | 1.05e-04 | 3.86e-06 | 27 | **2.65**
| | sp | 2.55e-04 | 2.83e-06 | 90 | 7.35e-05 | 2.73e-06 | 27 | **3.34**
| | lc | 2.74e-04 | 3.35e-06 | 82 | 9.09e-05 | 3.28e-06 | 28 | **2.94**
| | rc | 2.74e-04 | 3.31e-06 | 83 | 9.11e-05 | 3.29e-06 | 28 | **2.99**
| | op | 3.07e-04 | 3.68e-06 | 83 | 9.78e-05 | 3.59e-06 | 27 | **3.06**
| | rp | 4.35e-04 | 3.71e-06 | 117 | 1.25e-04 | 3.62e-06 | 35 | **3.40**
| | add | 7.22e-04 | 2.77e-06 | 260 | 6.80e-05 | 2.75e-06 | 25 | **10.55**
| | sub | 9.47e-04 | 2.85e-06 | 333 | 6.81e-05 | 2.77e-06 | 25 | **13.51**
| | neg | 4.09e-04 | 1.14e-06 | 358 | 4.36e-05 | 1.15e-06 | 38 | **9.43**
| | reverse | 3.14e-04 | 1.09e-06 | 287 | 4.48e-05 | 1.07e-06 | 42 | **6.89**
| | involute | 3.13e-04 | 1.10e-06 | 285 | 4.49e-05 | 1.06e-06 | 42 | **6.75**
| | conjugate | 3.62e-04 | 1.13e-06 | 322 | 4.49e-05 | 1.09e-06 | 41 | **7.78**
| | hodge | 3.30e-04 | 1.08e-06 | 306 | 4.65e-05 | 1.06e-06 | 44 | **6.95**
| | unhodge | 3.31e-04 | 1.07e-06 | 309 | 4.68e-05 | 1.04e-06 | 45 | **6.86**
| (4, 1) | | 1.63e-03 | | | 1.52e-03 |
| | gp | 3.49e-03 | 4.92e-05 | 71 | 1.39e-03 | 4.91e-05 | 28 | **2.51**
| | cp | 3.16e-03 | 2.50e-05 | 127 | 9.67e-04 | 2.50e-05 | 39 | **3.27**
| | acp | 3.23e-03 | 2.78e-05 | 116 | 1.02e-03 | 2.76e-05 | 37 | **3.14**
| | ip | 2.99e-03 | 2.40e-05 | 125 | 8.49e-04 | 2.39e-05 | 36 | **3.51**
| | sp | 2.55e-03 | 5.17e-06 | 493 | 4.05e-04 | 5.15e-06 | 79 | **6.27**
| | lc | 2.80e-03 | 1.45e-05 | 193 | 6.59e-04 | 1.45e-05 | 46 | **4.23**
| | rc | 2.79e-03 | 1.44e-05 | 194 | 6.58e-04 | 1.44e-05 | 46 | **4.24**
| | op | 2.81e-03 | 1.40e-05 | 200 | 6.04e-04 | 1.40e-05 | 43 | **4.63**
| | rp | 4.84e-03 | 1.41e-05 | 344 | 9.90e-04 | 1.40e-05 | 71 | **4.86**
| | add | 2.59e-03 | 4.62e-06 | 560 | 2.02e-04 | 4.55e-06 | 44 | **12.63**
| | sub | 3.46e-03 | 4.63e-06 | 748 | 2.02e-04 | 4.59e-06 | 44 | **16.97**
| | neg | 1.43e-03 | 2.15e-06 | 664 | 1.17e-04 | 2.16e-06 | 54 | **12.26**
| | reverse | 1.15e-03 | 2.05e-06 | 559 | 1.21e-04 | 2.04e-06 | 59 | **9.46**
| | involute | 1.05e-03 | 1.97e-06 | 532 | 1.21e-04 | 1.98e-06 | 61 | **8.67**
| | conjugate | 1.05e-03 | 1.96e-06 | 534 | 1.21e-04 | 1.96e-06 | 62 | **8.67**
| | hodge | 1.23e-03 | 1.91e-06 | 644 | 1.27e-04 | 1.92e-06 | 66 | **9.73**
| | unhodge | 1.23e-03 | 1.92e-06 | 642 | 1.28e-04 | 1.92e-06 | 67 | **9.65**
| (6,) | | 6.95e-03 | | | 6.45e-03 |
| | gp | 1.33e-02 | 1.91e-04 | 70 | 5.42e-03 | 1.89e-04 | 29 | **2.42**
| | cp | 1.20e-02 | 9.54e-05 | 126 | 3.70e-03 | 9.83e-05 | 38 | **3.34**
| | acp | 1.19e-02 | 9.83e-05 | 122 | 3.78e-03 | 1.00e-04 | 38 | **3.23**
| | ip | 1.07e-02 | 6.78e-05 | 158 | 2.68e-03 | 6.80e-05 | 39 | **3.99**
| | sp | 9.18e-03 | 8.76e-06 | 1048 | 1.22e-03 | 8.11e-06 | 151 | **6.94**
| | lc | 1.00e-02 | 3.80e-05 | 264 | 2.00e-03 | 3.75e-05 | 53 | **4.95**
| | rc | 9.95e-03 | 3.79e-05 | 263 | 1.98e-03 | 3.74e-05 | 53 | **4.97**
| | op | 9.98e-03 | 3.70e-05 | 269 | 1.79e-03 | 3.64e-05 | 49 | **5.48**
| | rp | 1.81e-02 | 3.81e-05 | 476 | 3.26e-03 | 3.65e-05 | 89 | **5.33**
| | add | 5.06e-03 | 7.35e-06 | 688 | 3.89e-04 | 6.88e-06 | 57 | **12.17**
| | sub | 6.78e-03 | 7.60e-06 | 891 | 3.88e-04 | 6.98e-06 | 56 | **16.04**
| | neg | 2.76e-03 | 3.68e-06 | 750 | 2.20e-04 | 3.53e-06 | 62 | **12.03**
| | reverse | 2.10e-03 | 3.28e-06 | 641 | 2.27e-04 | 3.15e-06 | 72 | **8.88**
| | involute | 2.02e-03 | 3.22e-06 | 625 | 2.29e-04 | 3.12e-06 | 73 | **8.52**
| | conjugate | 1.91e-03 | 3.17e-06 | 601 | 2.28e-04 | 3.02e-06 | 75 | **7.97**
| | hodge | 2.49e-03 | 3.25e-06 | 767 | 2.41e-04 | 3.03e-06 | 80 | **9.63**
| | unhodge | 2.49e-03 | 3.25e-06 | 767 | 2.40e-04 | 3.06e-06 | 78 | **9.78**

Creating large algebras was also very slow, because we precompute all the signs for products between basis blades. This has now been changed: for algebras of d > 6 we do not precompute this anymore, but instead populate the signs dictionary only on demand. This means large algebras are created quickly, although in the worst case the full cost is still incured once you start computing products.
| (p,q,r)  | from | to |
| -------- | ------- | ------- |
| (3,)        | 1.17e-04 | 1.15e-04 |
| (4,)        | 4.11e-04 | 3.77e-04 |
| (5,)        | 1.65e-03 | 1.53e-03 |
| (6,)        | 6.93e-03 | 6.55e-03 |
| (7,)        | 2.98e-02 | 3.95e-04 |
| (8,)        | 1.32e-01 | 8.22e-04 |
| (9,)        | 5.82e-01 | 1.76e-03 |
| (10,)       | 2.54e+00 | 3.78e-03 |