### PR TITLE
Fixed setattr discrepency when trying to set a basis blade with setattr.

### DIFF
--- a/kingdon/multivector.py
+++ b/kingdon/multivector.py
@@ -328,6 +328,19 @@ class MultiVector:
             return 0
         return self._values[idx] if swaps % 2 == 0 else - self._values[idx]
 
+    def __setattr__(self, basis_blade, value):
+        if not re.match(r'^e[0-9a-fA-F]*$', basis_blade):
+            return super().__setattr__(basis_blade, value)
+        if (key := self.algebra.canon2bin[basis_blade]) in self.keys():
+            self._values[key] = value
+        else:
+            raise TypeError("The keys of a MultiVector are immutable, please create a new MultiVector.")
+
+    def __delattr__(self, basis_blade, value):
+        if not re.match(r'^e[0-9a-fA-F]*$', basis_blade):
+            return super().__setattr__(basis_blade, value)
+        raise TypeError("The keys of a MultiVector are immutable, please create a new MultiVector.")
+
     def __contains__(self, item):
         item = item if isinstance(item, int) else self.algebra.canon2bin[item]
         return item in self._keys

--- a/tests/test_kingdon.py
+++ b/tests/test_kingdon.py
@@ -138,7 +138,7 @@ def test_reverse(R6):
     assert X.grade((0, 1, 4, 5)) == Xrev.grade((0, 1, 4, 5))
     assert X.grade((2, 3, 6)) == - Xrev.grade((2, 3, 6))
 
-def test_getattr(pga1d):
+def test_getattr_setattr(pga1d):
     X = pga1d.multivector({0: 2, 'e12': 3})
     assert X.e == 2 and X.e12 == 3
     assert X.e1 == 0 and X.e2 == 0
@@ -146,6 +146,15 @@ def test_getattr(pga1d):
     assert X.e3 == 0
     with pytest.raises(AttributeError):
         X.someattrthatdoesntexist
+
+    X.e = 3
+    assert X.e == 3
+    with pytest.raises(TypeError):
+        X.e1 = 5
+    assert dict(X.items()) == {0: 3, 3: 3}
+
+    with pytest.raises(TypeError):
+        del X.e
 
 def test_gp_symbolic(vga2d):
     u = vga2d.vector(name='u')


### PR DESCRIPTION
Doing
```py
x.e = 2
```
on a MV would work without raising an error, and `x.e` would also return `2`, but the coefficient was not actually added to the keys and values. In fact, the keys of a MV are immutable, so this should not be possible. This PR makes sure that if one attempts to set a basis blade like this, a useful error is raised. Same for delattr.