### PR TITLE
Make MultiVector "primary" operand in operations involving ndarrays

### DIFF
--- a/kingdon/multivector.py
+++ b/kingdon/multivector.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import reduce, cached_property
-from typing import Generator
+from typing import Generator, ClassVar
 from itertools import product
 import re
 
@@ -18,6 +18,10 @@ class MultiVector:
     algebra: "Algebra"
     _values: list = field(default_factory=list)
     _keys: tuple = field(default_factory=tuple)
+
+    # Make MultiVector "primary" operand in operations involving ndarray.
+    # (forces reflected (swapped) operands operations, like __radd__)
+    __array_priority__: ClassVar[int] = 1
 
     def __copy__(self):
         return self.fromkeysvalues(self.algebra, self._keys, self._values)
@@ -322,8 +326,6 @@ class MultiVector:
 
     def __getattr__(self, basis_blade):
         # TODO: if this first check is not true, raise hell instead?
-        if basis_blade == '__array_priority__':
-            return 0  # Numpy does this to decide the output type.
         if not re.match(r'^e[0-9a-fA-F]*$', basis_blade):
             raise AttributeError(f'{self.__class__.__name__} object has no attribute or basis blade {basis_blade}')
         basis_blade, swaps = self.algebra._blade2canon(basis_blade)

--- a/tests/test_kingdon.py
+++ b/tests/test_kingdon.py
@@ -1022,7 +1022,12 @@ def test_deep_copy_multivector(pga2d):
     assert copied_mv.e1[1] == [1]
 
 def test_swapped_operands(pga2d):
-    mv = pga2d.vector(e1=[[2], [1]], e2=[4, 0])
-    one = np.ones(3)
-    assert type(mv + one) is type(mv), 'ndarray took precedence as right-side operand'
-    assert type(one + mv) is type(mv), 'ndarray took precedence as left-side operand'
+    len_vector = len(pga2d.blades.grade(1))
+    uvals = np.random.random((len_vector, 2))
+    u = pga2d.vector(uvals)
+    one = np.ones(2)
+    expectedmv = pga2d.scalar(e=one) + pga2d.vector(uvals)
+    diff1 = (u + one) - expectedmv
+    diff2 = (one + u) - expectedmv
+    assert all(diff1.map(lambda v: np.allclose(v, 0.0)).values())
+    assert all(diff2.map(lambda v: np.allclose(v, 0.0)).values())

--- a/tests/test_kingdon.py
+++ b/tests/test_kingdon.py
@@ -1020,3 +1020,9 @@ def test_deep_copy_multivector(pga2d):
 
     mv.e1.append(1)
     assert copied_mv.e1[1] == [1]
+
+def test_swapped_operands(pga2d):
+    mv = pga2d.vector(e1=[[2], [1]], e2=[4, 0])
+    one = np.ones(3)
+    assert type(mv + one) is type(mv), 'ndarray took precedence as right-side operand'
+    assert type(one + mv) is type(mv), 'ndarray took precedence as left-side operand'

--- a/tests/test_kingdon.py
+++ b/tests/test_kingdon.py
@@ -1021,7 +1021,8 @@ def test_deep_copy_multivector(pga2d):
     mv.e1.append(1)
     assert copied_mv.e1[1] == [1]
 
-def test_swapped_operands(pga2d):
+def test_87(pga2d):
+    # Test if MVs operators are used when one of the arguments is a numpy ndarray.
     len_vector = len(pga2d.blades.grade(1))
     uvals = np.random.random((len_vector, 2))
     u = pga2d.vector(uvals)


### PR DESCRIPTION
Fixes #87

* Increase `MultiVector` class [`ndarray.__array_priority__`](https://numpy.org/doc/stable/user/c-info.beyond-basics.html#ndarray.__array_priority__) to make it a "primary" operand in operations where `ndarray` is the left-side operand
  This forces numpy NOT to perform such operations on its own, but to fall back to python "reflected (swapped) operands" operation, like [`__radd__`](https://docs.python.org/3.13/reference/datamodel.html#object.__radd__)

* The `__array_priority__` is made "regular" class attribute. Since this is a `@dataclass`, a `ClassVar` annotation is added to keep it a [class variable](https://docs.python.org/3.13/library/dataclasses.html#class-variables).

* Some very minimal pytest is added, to test the `type` of the add-result when `ndarray` is right and left side operand
  _This test should need extra updates_