### PR TITLE
Fix 101

### DIFF
--- a/kingdon/algebra.py
+++ b/kingdon/algebra.py
@@ -117,7 +117,7 @@ class Algebra:
     cse: bool = field(default=True, repr=False)  # Common Subexpression Elimination (CSE)
     graded: bool = field(default=False, repr=False)  # If true, precompute products per grade.
     pretty_blade: str = field(default='𝐞', repr=False, compare=False)
-    pretty_digits: dict = field(default_factory=dict, init=False, repr=False, compare=False)
+    pretty_digits: dict = field(default_factory=dict, init=False, repr=False, compare=False)  # TODO: this can be defined outside Algebra
 
     # Codegen & call customization.
     # Wrapper function applied to the codegen generated functions.
@@ -221,30 +221,30 @@ class Algebra:
     def __len__(self):
         return 2 ** self.d
 
-    def indices_for_grade(self, grade: int) -> tuple:
+    def indices_for_grade(self, grade: int):
         """
-        Function that generates all the indices for a given grade. E.g. in 2D VGA, this returns
+        Function that returns a generator for all the indices for a given grade. E.g. in 2D VGA, this returns
 
         .. code-block ::
 
             >>> alg = Algebra(2)
-            >>> alg.indices_for_grade(1)
+            >>> tuple(alg.indices_for_grade(1))
             (1, 2)
         """
-        return tuple((sum(2**bin for bin in bins)) for bins in combinations(range(self.d), r=grade))
+        return (sum(2**bin for bin in bins) for bins in combinations(range(self.d), r=grade))
 
-    def indices_for_grades(self, grades: Tuple[int]) -> tuple:
+    def indices_for_grades(self, grades: Tuple[int]):
         """
-        Function that generates indices from a sequence of grades.
+        Function that returns a generator for all the indices from a sequence of grades.
         E.g. in 2D VGA, this returns
 
         .. code-block ::
 
             >>> alg = Algebra(2)
-            >>> alg.indices_for_grades((1, 2))
+            >>> tuple(alg.indices_for_grades((1, 2)))
             (1, 2, 3)
         """
-        return tuple(chain.from_iterable(self.indices_for_grade(grade) for grade in sorted(grades)))
+        return (chain.from_iterable(self.indices_for_grade(grade) for grade in sorted(grades)))
 
     @cached_property
     def matrix_basis(self):

--- a/kingdon/algebra.py
+++ b/kingdon/algebra.py
@@ -462,7 +462,12 @@ class Algebra:
 
         :param `*subjects`: Subjects to be graphed.
             Can be strings, hexadecimal colors, (lists of) MultiVector, (lists of) callables.
-        :param `**options`: Options passed to :code:`ganja.js`'s :code:`Algebra.graph`.
+        :param camera: [optional] a motor that places the camera at the desired viewpoint.
+        :param up: [optional] the 'up' (C) function that takes a Euclidean point and casts it into a larger
+            embedding space. This will invoke ganja's OPNS renderer, which can be used to render any algebra.
+            Examples include 2D CSGA, 3D CCGA, 3D Mother Algebra, etc. See the teahouse for examples.
+        :param `**options`: Other options passed to :code:`ganja.js`'s :code:`Algebra.graph`.
+
         """
         return graph_widget(
             algebra=self,

--- a/kingdon/algebra.py
+++ b/kingdon/algebra.py
@@ -112,12 +112,12 @@ class Algebra:
     # Mappings from binary to canonical reps. e.g. 0b01 = 1 <-> 'e1', 0b11 = 3 <-> 'e12'.
     canon2bin: dict = field(init=False, repr=False, compare=False)
     bin2canon: dict = field(init=False, repr=False, compare=False)
-    _bin2canon_prettystr: dict = field(init=False, repr=False, compare=False)
 
     # Options for the algebra
     cse: bool = field(default=True, repr=False)  # Common Subexpression Elimination (CSE)
     graded: bool = field(default=False, repr=False)  # If true, precompute products per grade.
     pretty_blade: str = field(default='𝐞', repr=False, compare=False)
+    pretty_digits: dict = field(default_factory=dict, init=False, repr=False, compare=False)
 
     # Codegen & call customization.
     # Wrapper function applied to the codegen generated functions.
@@ -162,19 +162,24 @@ class Algebra:
             self.bin2canon = {J: eJ for eJ, J in sorted(self.canon2bin.items(), key=lambda x: x[1])}
         else:
             self.bin2canon = {
-                eJ: 'e' + ''.join(hex(num + self.start_index - 1)[2:] for ei in range(0, self.d) if (num := (eJ & 2**ei).bit_length()))
+                eJ: 'e' + ''.join(format(num + self.start_index - 1, 'X') for ei in range(0, self.d) if (num := (eJ & 2**ei).bit_length()))
                 for eJ in range(2 ** self.d)
             }
             self.canon2bin = dict(sorted({c: b for b, c in self.bin2canon.items()}.items(), key=lambda x: (len(x[0]), x[0])))
 
-        def pretty_blade(blade):
-            if blade == 'e':
-                return '1'
-            blade = self.pretty_blade + blade[1:]
-            for old, new in tuple(zip("0123456789", "₀₁₂₃₄₅₆₇₈₉")):
-                blade = blade.replace(old, new)
-            return blade
-        self._bin2canon_prettystr = {k: pretty_blade(v) for k, v in self.bin2canon.items()}
+        if self.d + self.start_index <= 10:
+            self.pretty_digits = {'0': '₀', '1': '₁', '2': '₂', '3': '₃', '4': '₄', '5': '₅', '6': '₆', '7': '₇', '8': '₈', '9': '₉',}
+        else:
+            # Use superscript above 10 because that is almost the entire alphabet.
+            self.pretty_digits = {
+                '0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
+                '5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹',
+                'A': 'ᴬ', 'B': 'ᴮ', 'C': 'ᶜ', 'D': 'ᴰ', 'E': 'ᴱ',
+                'F': 'ᶠ', 'G': 'ᴳ', 'H': 'ᴴ', 'I': 'ᴵ', 'J': 'ᴶ',
+                'K': 'ᴷ', 'L': 'ᴸ', 'M': 'ᴹ', 'N': 'ᴺ', 'O': 'ᴼ',
+                'P': 'ᴾ', 'R': 'ᴿ', 'Q': 'Q', 'S': 'ˢ', 'T': 'ᵀ', 'U': 'ᵁ',
+                'V': 'ⱽ', 'W': 'ᵂ', 'X': 'ˣ', 'Y': 'ʸ', 'Z': 'ᶻ'
+            }
 
         self.signs = self._prepare_signs()
 

--- a/kingdon/codegen.py
+++ b/kingdon/codegen.py
@@ -592,7 +592,7 @@ def do_codegen(codegen, *mvs) -> CodegenOutput:
         dependencies = res.dependencies
         res = res.expr_dict
     else:
-        funcname = f'{codegen.__name__}_' + '_x_'.join(f"{mv.type_number}" for mv in mvs)
+        funcname = f'{codegen.__name__}_' + '_x_'.join(f"{format(mv.type_number, 'X')}" for mv in mvs)
         args = {arg_name: arg.values() for arg_name, arg in zip(string.ascii_uppercase, mvs)}
         dependencies = None
 

--- a/kingdon/graph.js
+++ b/kingdon/graph.js
@@ -8,11 +8,27 @@ function render({ model, el }) {
         var key2idx = model.get('key2idx');
         var draggable_points_idxs = model.get('draggable_points_idxs');
         var options = model.get('options');
+        var d = model.get('signature').length;
+
+        function grade(key) {
+            var count = 0;
+            while (key) {
+                count += key & 1;
+                key >>= 1;
+            }
+            return count;
+        }
 
         // Define helper functions.
         var toElement = (o)=>{
             /* convert object to Element */
             var _values = o['mv'] instanceof DataView?new Float64Array(o['mv'].buffer):o['mv'];
+            if ('grades' in o) {
+                var values = new Element();
+                o['grades'].forEach(grade=>values[grade] = []);
+                o['keys'].forEach((k, j)=>{var g = grade(k); values[g][key2idx[g][k]] = _values[j]});
+                return values;
+            }
             if ('keys' in o) {
                 var values = Array(Object.keys(key2idx).length).fill(0);
                 o['keys'].forEach((k, j)=>values[key2idx[k]] = _values[j]);

--- a/kingdon/multivector.py
+++ b/kingdon/multivector.py
@@ -91,10 +91,10 @@ class MultiVector:
             keys, values = zip(*values.items()) if values else (tuple(), list())
             values = list(values)
         elif len(values) == sum(math.comb(algebra.d, grade) for grade in grades) and not keys:
-            keys = algebra.indices_for_grades(grades)
+            keys = tuple(algebra.indices_for_grades(grades))
         elif name and not values:
             # values was not given, but we do have a name. So we are in symbolic mode.
-            keys = algebra.indices_for_grades(grades) if not keys else keys
+            keys = tuple(algebra.indices_for_grades(grades)) if not keys else keys
             values = list(symbolcls(f'{name}{algebra.bin2canon[k][1:]}') for k in keys)
         elif len(keys) != len(values):
             raise TypeError(f'Length of `keys` and `values` have to match.')

--- a/kingdon/multivector.py
+++ b/kingdon/multivector.py
@@ -339,7 +339,7 @@ class MultiVector:
         # TODO: if this first check is not true, raise hell instead?
         if basis_blade == '__array_priority__':
             return 0  # Numpy does this to decide the output type.
-        if not re.match(r'^e[0-9a-fA-F]*$', basis_blade):
+        if not re.match(r'^e[0-9a-fA-Z]*$', basis_blade):
             raise AttributeError(f'{self.__class__.__name__} object has no attribute or basis blade {basis_blade}')
         basis_blade, swaps = self.algebra._blade2canon(basis_blade)
         if basis_blade not in self.algebra.canon2bin:
@@ -351,7 +351,7 @@ class MultiVector:
         return self._values[idx] if swaps % 2 == 0 else - self._values[idx]
 
     def __setattr__(self, basis_blade, value):
-        if not re.match(r'^e[0-9a-fA-F]*$', basis_blade):
+        if not re.match(r'^e[0-9a-fA-Z]*$', basis_blade):
             return super().__setattr__(basis_blade, value)
         if (key := self.algebra.canon2bin[basis_blade]) in self.keys():
             self._values[key] = value
@@ -359,7 +359,7 @@ class MultiVector:
             raise TypeError("The keys of a MultiVector are immutable, please create a new MultiVector.")
 
     def __delattr__(self, basis_blade, value):
-        if not re.match(r'^e[0-9a-fA-F]*$', basis_blade):
+        if not re.match(r'^e[0-9a-fA-Z]*$', basis_blade):
             return super().__setattr__(basis_blade, value)
         raise TypeError("The keys of a MultiVector are immutable, please create a new MultiVector.")
 

--- a/kingdon/multivector.py
+++ b/kingdon/multivector.py
@@ -285,7 +285,13 @@ class MultiVector:
                 return s
             return f'({s})'
 
-        canon_sorted_vals = {self.algebra._bin2canon_prettystr[key]: val for key, val in self.items()}
+        def print_key(blade):
+            if blade == 'e':
+                return '1'
+            return self.algebra.pretty_blade + ''.join(self.algebra.pretty_digits[num] for num in blade[1:])
+
+        canon_sorted_vals = {print_key(self.algebra.bin2canon[key]): val
+                             for key, val in self.items()}
         str_repr = ' + '.join(
             [f'{print_value(val)} {blade}' if blade != '1' else f'{print_value(val)}'
              for blade, val in canon_sorted_vals.items() if (val.any() if hasattr(val, 'any') else val)]
@@ -300,9 +306,7 @@ class MultiVector:
 
     def __format__(self, format_spec):
         if format_spec == 'keys_binary':
-            iden = '_'.join(''.join('1' if i in self.keys() else '0' for i in bin_blades)
-                            for bin_blades in self.algebra.indices_for_grade.values())
-            return iden
+            return bin(self.type_number)[2:].zfill(len(self.algebra))
         return str(self)
 
     def __getitem__(self, item):

--- a/kingdon/multivector.py
+++ b/kingdon/multivector.py
@@ -69,7 +69,7 @@ class MultiVector:
         if keys is not None and not all(isinstance(k, int) for k in keys):
             keys = tuple(k if k in algebra.bin2canon else algebra.canon2bin[k] for k in keys)
         if grades is None and name and keys is not None:
-            grades = tuple(sorted({format(k, 'b').count('1') for k in keys}))
+            grades = tuple(sorted({_bit_count(k) for k in keys}))
         values = values if values is not None else list()
         keys = keys if keys is not None else tuple()
 

--- a/kingdon/operator_dict.py
+++ b/kingdon/operator_dict.py
@@ -72,7 +72,7 @@ def do_operation(*mvs, codegen, algebra) -> MultiVector:
     """
     This function just does the operation directly on the MV's, no codegen is performed.
     This is used for large algebras, where codegen is too costly.
-    The result is the multivector resulting from codegen(*mvs).
+    The result is the multivector resulting from :code:`codegen(*mvs)`.
     """
     mvs = [mv if isinstance(mv, MultiVector) else MultiVector.fromkeysvalues(algebra, (0,), (mv,))
            for mv in mvs]

--- a/kingdon/taperecorder.py
+++ b/kingdon/taperecorder.py
@@ -24,7 +24,7 @@ class TapeRecorder:
         return int(''.join('1' if i in self.keys() else '0' for i in reversed(self.algebra.canon2bin.values())), 2)
 
     def __getattr__(self, basis_blade):
-        if not re.match(r'^e[0-9a-fA-F]*$', basis_blade):
+        if not re.match(r'^e[0-9a-fA-Z]*$', basis_blade):
             raise AttributeError(f'{self.__class__.__name__} object has no attribute or basis blade {basis_blade}')
         if basis_blade not in self.algebra.canon2bin:
             return self.__class__(

--- a/kingdon/taperecorder.py
+++ b/kingdon/taperecorder.py
@@ -51,7 +51,7 @@ class TapeRecorder:
         if len(grades) == 1 and isinstance(grades[0], tuple):
             grades = grades[0]
 
-        basis_blades = self.algebra.indices_for_grades[grades]
+        basis_blades = self.algebra.indices_for_grades(grades)
         indices_keys = [(idx, k) for idx, k in enumerate(self.keys()) if k in basis_blades]
         indices, keys = zip(*indices_keys) if indices_keys else (tuple(), tuple())
         expr = f"[{self.expr}[idx] for idx in {indices}]"

--- a/kingdon/taperecorder.py
+++ b/kingdon/taperecorder.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from functools import cached_property, partial, partialmethod
+import re
 
 
 @dataclass(init=False)
@@ -51,7 +52,7 @@ class TapeRecorder:
         if len(grades) == 1 and isinstance(grades[0], tuple):
             grades = grades[0]
 
-        basis_blades = self.algebra.indices_for_grades(grades)
+        basis_blades = tuple(self.algebra.indices_for_grades(grades))
         indices_keys = [(idx, k) for idx, k in enumerate(self.keys()) if k in basis_blades]
         indices, keys = zip(*indices_keys) if indices_keys else (tuple(), tuple())
         expr = f"[{self.expr}[idx] for idx in {indices}]"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -12,3 +12,28 @@ def test_widget():
     assert g.draggable_points == [[{'keys': x.keys(), 'mv': x.values()}]]
     assert all(type(s) == int for s in g.signature)
 
+def test_up_function():
+    """ Issue 93 implements the up function in graph, which enables OPNS rendering for exotic algebras like 2D CSGA. """
+    import sympy as sp
+    from sympy.printing.glsl import GLSLPrinter
+
+    alg = Algebra(5, 3)
+    e1, e2 = [alg.vector({key: 1}) for key in ['e1', 'e2']]
+    p1, p2, p3 = [alg.vector({key: 1}) for key in ['e3', 'e4', 'e5']]
+    n1, n2, n3 = [alg.vector({key: 1}) for key in ['e6', 'e7', 'e8']]
+
+    # infinity (i) and origin (o) : plus (p), minus (m), times (t).
+    ip, im, it = [n1 - p1, n2 - p2, n3 - p3]
+    op, om, ot = alg.scalar(e=0.5) * [n1 + p1, n2 + p2, n3 + p3]
+
+    # The 'up' (C) function that takes a Euclidean point and casts it into R5,3
+    def up(x, y):
+        return op + x * e1 + y * e2 + 0.5 * (x * x + y * y) * ip + 0.5 * (x * x - y * y) * im + x * y * it
+
+    # The up function should be converted to a list of strings with valid GLSL syntax:
+    up_mv = up(sp.Symbol('x'), sp.Symbol('y'))
+    up_glsl = up_mv.map(GLSLPrinter().doprint)
+
+    # Lets see what the graph object does.
+    g = alg.graph(lambda: [], animate=0, up=up)
+    assert g.options['up'] == up_glsl.values()

--- a/tests/test_kingdon.py
+++ b/tests/test_kingdon.py
@@ -1027,4 +1027,9 @@ def test_101():
     # No news is good news, because with kingdon <= 1.5.1 this raised a MemoryError
     alg = Algebra(16)
     basisvectors = [alg.vector(keys=(2 ** i,), values=(1.0,)) for i in range(alg.d)]
-    assert basisvectors[0] * basisvectors[1] == basisvectors[0] ^ basisvectors[1]
+    e0, e1, e2, e3, *rest = basisvectors
+    e01, e02, e03 = e0 ^ e1, e0 ^ e2, e0 ^ e3
+    assert e01 == e0 * e1
+    spine = sum(basisvectors[2*i] * basisvectors[2*i+1] for i in range(alg.d // 2))
+    box = (1j*spine).outerexp().map(lambda v: v.real).filter()
+    assert e01 * e02 * box == - e03 * box

--- a/tests/test_kingdon.py
+++ b/tests/test_kingdon.py
@@ -505,7 +505,7 @@ def test_multidimensional_indexing():
     alg = Algebra(4)
     nrows = 3
     ncolumns = 4
-    shape = (len(alg.indices_for_grade(2)), nrows, ncolumns)
+    shape = (len(tuple(alg.indices_for_grade(2))), nrows, ncolumns)
     bvals = np.random.random(shape)
     B = alg.bivector(bvals)
     np.testing.assert_allclose(B[2:4].e12, bvals[0, 2:4])
@@ -550,12 +550,12 @@ def test_clifford_involutions():
 
 
 def test_normalization(pga3d):
-    vvals = np.random.random(len(pga3d.indices_for_grade(1)))
+    vvals = np.random.random(len(tuple(pga3d.indices_for_grade(1))))
     v = pga3d.vector(vvals).normalized()
     assert (v*v).e == pytest.approx(1.0)
 
     # Normalizing a non-simple bivector makes it simple!
-    bvals = np.random.random(len(pga3d.indices_for_grade(2)))
+    bvals = np.random.random(len(tuple(pga3d.indices_for_grade(2))))
     B = pga3d.bivector(bvals)
     Bnormalized = B.normalized()
     assert Bnormalized.normsq().e == pytest.approx(1.0)
@@ -565,7 +565,7 @@ def test_normalization(pga3d):
 def test_itermv():
     alg = Algebra(4)
     nrows = 3
-    shape = (len(alg.indices_for_grade(2)), nrows)
+    shape = (len(tuple(alg.indices_for_grade(2))), nrows)
     bvals = np.random.random(shape)
     B = alg.bivector(bvals)
     for i, b in enumerate(B.itermv()):
@@ -621,7 +621,7 @@ def test_graded():
 
     for b in alg.blades.values():
         assert len(b.grades) == 1
-        assert b.keys() == alg.indices_for_grades(b.grades)
+        assert b.keys() == tuple(alg.indices_for_grades(b.grades))
 
     with pytest.raises(ValueError):
         # In graded mode, the keys have to be correct.
@@ -649,7 +649,7 @@ def test_blade_dict():
     alg = Algebra(7, graded=True)
     assert alg.blades.lazy
     assert len(alg.blades) == 1  # PSS is calculated by default
-    assert len(alg.blades['e12']) == len(alg.indices_for_grade(2))
+    assert len(alg.blades['e12']) == len(tuple(alg.indices_for_grade(2)))
     assert len(alg.blades) == 2
 
 
@@ -832,7 +832,7 @@ def test_blades_of_grade():
     alg = Algebra(4)
     grade_combinations = [comb for r in range(alg.d + 2) for comb in itertools.combinations(tuple(range(alg.d + 1)), r=r)]
     for comb in grade_combinations:
-        indices = alg.indices_for_grades(comb)
+        indices = tuple(alg.indices_for_grades(comb))
         blades_of_grade = alg.blades.grade(*indices)
         assert isinstance(blades_of_grade, dict)
         assert all(label in alg.canon2bin and blade.grades[0] in indices

--- a/tests/test_kingdon.py
+++ b/tests/test_kingdon.py
@@ -1046,8 +1046,8 @@ def test_large():
 
     for op_name, op_large in alg_large.registry.items():
         op_small = alg_small.registry.get(op_name)
-        if op_name != 'sqrt':
-            continue
+        if op_name == 'sqrt':
+            continue  # Sqrt is a bit of a Heisenbug due to numerical errors
 
         if isinstance(op_small, UnaryOperatorDict):
             xy_large = op_large(x)


### PR DESCRIPTION
Better support for large (d > 10) algebras.
- [x] Turn 'indices_for_grade' and 'indices_for_grades' into functions instead of a dict, since this caused a MemoryError for large algebras but you rarely need this so it probably doesn't make sense to cache it.
- [x] Improved printing of basis blades when d > 10.
- [ ] Time(it) the impact of these changes on small algebras. Particularly, wether the caching had a big impact on performance.
- [x] Make sure `indices_for_grade(s)` is not used in MultiVector but replace it with binary ops on typenumber. (Use indices_for_grade only upon instantiation, but for nothing else.)
- [x] Support `up` function so large algebras can be visualized (#93)
- [x] For large algebras disable codegen and just do a brute force computation. This also requires some rewriting of codegen to make sure any codegen function can also be directly evaluated on a multivector to perform the computation. This will also make this part of the codebase a lot cleaner, but it might negatively impact the performance of inv/div in particular.
- [x] Tests
- [x] Documentation
- [x] Add examples to teahouse